### PR TITLE
Fix includes to allow for ARM architectures (M0)

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -46,8 +46,10 @@
 #if defined(__AVR__)
 #include <avr/pgmspace.h>
 #include <util/delay.h>
-#else
+#elif defined(ESP8266) || defined(ESP32)
 #include "pgmspace.h"
+#else 
+#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #endif
 #include <stdlib.h>
 


### PR DESCRIPTION
Expanded the include section to allow for compilation on non-AVR architectures like the Cortex M0. 