### PR TITLE
Force disable spread spectrum output

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -112,6 +112,9 @@ err_t Adafruit_SI5351::begin(TwoWire *theWire) {
   ASSERT_STATUS(write8(SI5351_REGISTER_183_CRYSTAL_INTERNAL_LOAD_CAPACITANCE,
                        m_si5351Config.crystalLoad));
 
+  /* Disable spread spectrum output. */
+  enableSpreadSpectrum(false);
+
   /* Set interrupt masks as required (see Register 2 description in AN619).
      By default, ClockBuilder Desktop sets this register to 0x18.
      Note that the least significant nibble must remain 0x8, but the most
@@ -514,6 +517,24 @@ err_t Adafruit_SI5351::enableOutputs(bool enabled) {
   /* Enabled desired outputs (see Register 3) */
   ASSERT_STATUS(
       write8(SI5351_REGISTER_3_OUTPUT_ENABLE_CONTROL, enabled ? 0x00 : 0xFF));
+
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Enables or disables spread spectrum
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::enableSpreadSpectrum(bool enabled) {
+  uint8_t regval;
+  ASSERT_STATUS(read8(SI5351_REGISTER_149_SPREAD_SPECTRUM_PARAMETERS, &regval));
+  if (enabled) {
+    regval |= 0x80;
+  } else {
+    regval &= ~0x80;
+  }
+  ASSERT_STATUS(write8(SI5351_REGISTER_149_SPREAD_SPECTRUM_PARAMETERS, regval));
 
   return ERROR_NONE;
 }

--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -508,6 +508,8 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
 /**************************************************************************/
 /*!
     @brief  Enables or disables all clock outputs
+    @param  enabled Whether output is enabled
+    @return ERROR_NONE
 */
 /**************************************************************************/
 err_t Adafruit_SI5351::enableOutputs(bool enabled) {
@@ -524,6 +526,8 @@ err_t Adafruit_SI5351::enableOutputs(bool enabled) {
 /**************************************************************************/
 /*!
     @brief  Enables or disables spread spectrum
+    @param  enabled Whether spread spectrum output is enabled
+    @return ERROR_NONE
 */
 /**************************************************************************/
 err_t Adafruit_SI5351::enableSpreadSpectrum(bool enabled) {

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -282,11 +282,8 @@ public:
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
                            si5351MultisynthDiv_t div); //!< @return ERROR_NONE
-                                                       /*!
-                                                        * @param enabled Whether output is enabled
-                                                        * @return ERROR_NONE
-                                                        */
-  err_t enableSpreadSpectrum(bool enabled);            //!< @return ERROR_NONE
+
+  err_t enableSpreadSpectrum(bool enabled);
   err_t enableOutputs(bool enabled);
   /*!
    * @param output Enables or disables output

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -208,6 +208,7 @@ enum {
   SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS = 90,
   SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS = 91,
   SI5351_REGISTER_092_CLOCK_6_7_OUTPUT_DIVIDER = 92,
+  SI5351_REGISTER_149_SPREAD_SPECTRUM_PARAMETERS = 149,
   SI5351_REGISTER_165_CLK0_INITIAL_PHASE_OFFSET = 165,
   SI5351_REGISTER_166_CLK1_INITIAL_PHASE_OFFSET = 166,
   SI5351_REGISTER_167_CLK2_INITIAL_PHASE_OFFSET = 167,
@@ -286,6 +287,7 @@ public:
                                                         * @return ERROR_NONE
                                                         */
   err_t enableOutputs(bool enabled);
+  err_t enableSpreadSpectrum(bool enabled);
   /*!
    * @param output Enables or disables output
    * @param div Set of output divider values (2^n, n=1..7)

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -286,8 +286,8 @@ public:
                                                         * @param enabled Whether output is enabled
                                                         * @return ERROR_NONE
                                                         */
+  err_t enableSpreadSpectrum(bool enabled);            //!< @return ERROR_NONE
   err_t enableOutputs(bool enabled);
-  err_t enableSpreadSpectrum(bool enabled);
   /*!
    * @param output Enables or disables output
    * @param div Set of output divider values (2^n, n=1..7)


### PR DESCRIPTION
Adds a call to explicitly disable spread spectrum output. This is done using the `SSC_EN` bit in the the Spread Spectrum Parameters register 149 per AN619 via new class method `enableSpreadSpectrum()`.

![image](https://user-images.githubusercontent.com/8755041/143957864-06a9bc96-7d30-4802-bd75-bf4e55a848ca.png)
