### PR TITLE
Issues #15

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -401,7 +401,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   uint32_t P1; /* Multisynth config register P1 */
   uint32_t P2; /* Multisynth config register P2 */
   uint32_t P3; /* Multisynth config register P3 */
-
+  uint8_t DIVBY4=0;
   /* Basic validation */
   ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
   ASSERT(output < 3, ERROR_INVALIDPARAMETER);       /* Channel range */
@@ -441,6 +441,14 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
     P1 = 128 * div - 512;
     P2 = 0;
     P3 = denom;
+    if ( div == 4 )
+    {
+        DIVBY4 = 0b1100;
+    }
+    else
+    {
+        DIVBY4 = 0b0000;
+    }
   } else if (denom == 1) {
     /* Fractional mode, simplified calculations */
     P1 = 128 * div + 128 * num - 512;
@@ -474,7 +482,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   sendBuffer[0] = baseaddr;
   sendBuffer[1] = (P3 & 0xFF00) >> 8;
   sendBuffer[2] = P3 & 0xFF;
-  sendBuffer[3] = ((P1 & 0x30000) >> 16) | lastRdivValue[output];
+  sendBuffer[3] = ((P1 & 0x30000) >> 16) | lastRdivValue[output] | DIVBY4;
   sendBuffer[4] = (P1 & 0xFF00) >> 8;
   sendBuffer[5] = P1 & 0xFF;
   sendBuffer[6] = ((P3 & 0xF0000) >> 12) | ((P2 & 0xF0000) >> 16);


### PR DESCRIPTION
SI5351_MULTISYNTH_DIV_4 does not work correctly

I found that multisynth with div=4 does not work correctly.
According to AN619, MSx_DIVBY4[1:0] must be 11b, when div=4.
I will send you suggested revisions.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
