### PR TITLE
Enable phase offset function

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -275,10 +275,7 @@ err_t Adafruit_SI5351::setupPLL(si5351PLL_t pll, uint8_t mult, uint32_t num,
                        ((P3 & 0x000F0000) >> 12) | ((P2 & 0x000F0000) >> 16)));
   ASSERT_STATUS(write8(baseaddr + 6, (P2 & 0x0000FF00) >> 8));
   ASSERT_STATUS(write8(baseaddr + 7, (P2 & 0x000000FF)));
-
-  /* Reset both PLLs */
-  ASSERT_STATUS(write8(SI5351_REGISTER_177_PLL_RESET, (1 << 7) | (1 << 5)));
-
+  
   /* Store the frequency settings for use with the Multisynth helper */
   if (pll == SI5351_PLL_A) {
     float fvco =
@@ -520,7 +517,16 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
     ASSERT_STATUS(write8(SI5351_REGISTER_18_CLK2_CONTROL, clkControlReg));
     break;
   }
-
+  
+  /* Reset PLL */
+  switch (pllSource) {
+  case SI5351_PLL_A:
+    ASSERT_STATUS(write8(SI5351_REGISTER_177_PLL_RESET, (1 << 5)));
+    break;
+  default:
+    ASSERT_STATUS(write8(SI5351_REGISTER_177_PLL_RESET, (1 << 7)));
+  }
+  
   return ERROR_NONE;
 }
 

--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -275,7 +275,7 @@ err_t Adafruit_SI5351::setupPLL(si5351PLL_t pll, uint8_t mult, uint32_t num,
                        ((P3 & 0x000F0000) >> 12) | ((P2 & 0x000F0000) >> 16)));
   ASSERT_STATUS(write8(baseaddr + 6, (P2 & 0x0000FF00) >> 8));
   ASSERT_STATUS(write8(baseaddr + 7, (P2 & 0x000000FF)));
-  
+
   /* Store the frequency settings for use with the Multisynth helper */
   if (pll == SI5351_PLL_A) {
     float fvco =
@@ -381,11 +381,11 @@ err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
         or 8..900 in fractional mode (MSx_INT=0).
     b = The fractional numerator (0..1,048,575)
     c = The fractional denominator (1..1,048,575)
-    
+
     The phase delay in seconds applied to the output is:
-    
+
         phaseOffset / (4 * fVCO)
-    
+
     @note   Try to use integers whenever possible to avoid clock jitter
 
     @note   For output frequencies > 150MHz, you must set the divider
@@ -484,20 +484,23 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   sendBuffer[7] = (P2 & 0xFF00) >> 8;
   sendBuffer[8] = P2 & 0xFF;
   ASSERT_STATUS(writeN(sendBuffer, 9));
-  
+
   /* Set phase offset */
   switch (output) {
   case 0:
-    ASSERT_STATUS(write8(SI5351_REGISTER_165_CLK0_INITIAL_PHASE_OFFSET, phaseOffset));
+    ASSERT_STATUS(
+        write8(SI5351_REGISTER_165_CLK0_INITIAL_PHASE_OFFSET, phaseOffset));
     break;
   case 1:
-    ASSERT_STATUS(write8(SI5351_REGISTER_166_CLK1_INITIAL_PHASE_OFFSET, phaseOffset));
+    ASSERT_STATUS(
+        write8(SI5351_REGISTER_166_CLK1_INITIAL_PHASE_OFFSET, phaseOffset));
     break;
   case 2:
-    ASSERT_STATUS(write8(SI5351_REGISTER_167_CLK2_INITIAL_PHASE_OFFSET, phaseOffset));
+    ASSERT_STATUS(
+        write8(SI5351_REGISTER_167_CLK2_INITIAL_PHASE_OFFSET, phaseOffset));
     break;
   }
-  
+
   /* Configure the clk control and enable the output */
   /* TODO: Check if the clk control byte needs to be updated. */
   uint8_t clkControlReg = 0x0F; /* 8mA drive strength, MS0 as CLK0 source, Clock
@@ -517,7 +520,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
     ASSERT_STATUS(write8(SI5351_REGISTER_18_CLK2_CONTROL, clkControlReg));
     break;
   }
-  
+
   /* Reset PLL */
   switch (pllSource) {
   case SI5351_PLL_A:
@@ -526,7 +529,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   default:
     ASSERT_STATUS(write8(SI5351_REGISTER_177_PLL_RESET, (1 << 7)));
   }
-  
+
   return ERROR_NONE;
 }
 

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -279,7 +279,7 @@ public:
                  uint32_t denom);                   //!< @return ERROR_NONE
   err_t setupPLLInt(si5351PLL_t pll, uint8_t mult); //!< @return ERROR_NONE
   err_t setupMultisynth(uint8_t output, si5351PLL_t pllSource, uint32_t div,
-                        uint32_t num, uint32_t denom); //!< @return ERROR_NONE
+                        uint32_t num, uint32_t denom, uint8_t phaseOffset); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
                            si5351MultisynthDiv_t div); //!< @return ERROR_NONE
 

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -279,7 +279,8 @@ public:
                  uint32_t denom);                   //!< @return ERROR_NONE
   err_t setupPLLInt(si5351PLL_t pll, uint8_t mult); //!< @return ERROR_NONE
   err_t setupMultisynth(uint8_t output, si5351PLL_t pllSource, uint32_t div,
-                        uint32_t num, uint32_t denom, uint8_t phaseOffset); //!< @return ERROR_NONE
+                        uint32_t num, uint32_t denom,
+                        uint8_t phaseOffset); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
                            si5351MultisynthDiv_t div); //!< @return ERROR_NONE
 

--- a/examples/si5351/si5351.ino
+++ b/examples/si5351/si5351.ino
@@ -36,7 +36,7 @@ void setup(void)
   /* Setup Multisynth 1 to 13.55311MHz (PLLB/45.5) */
   clockgen.setupPLL(SI5351_PLL_B, 24, 2, 3);
   Serial.println("Set Output #1 to 13.553115MHz");
-  clockgen.setupMultisynth(1, SI5351_PLL_B, 45, 1, 2);
+  clockgen.setupMultisynth(1, SI5351_PLL_B, 45, 1, 2, 0);
 
   /* Multisynth 2 is not yet used and won't be enabled, but can be */
   /* Use PLLB @ 616.66667MHz, then divide by 900 -> 685.185 KHz */
@@ -44,7 +44,7 @@ void setup(void)
   /* configured using either PLL in either integer or fractional mode */
 
   Serial.println("Set Output #2 to 10.706 KHz");
-  clockgen.setupMultisynth(2, SI5351_PLL_B, 900, 0, 1);
+  clockgen.setupMultisynth(2, SI5351_PLL_B, 900, 0, 1, 0);
   clockgen.setupRdiv(2, SI5351_R_DIV_64);
 
   /* Enable the clocks */

--- a/examples/si5351/si5351.ino
+++ b/examples/si5351/si5351.ino
@@ -7,17 +7,18 @@ Adafruit_SI5351 clockgen = Adafruit_SI5351();
     Arduino setup function (automatically called at startup)
 */
 /**************************************************************************/
-void setup(void)
-{
+void setup(void) {
   Serial.begin(9600);
-  Serial.println("Si5351 Clockgen Test"); Serial.println("");
+  Serial.println("Si5351 Clockgen Test");
+  Serial.println("");
 
   /* Initialise the sensor */
-  if (clockgen.begin() != ERROR_NONE)
-  {
+  if (clockgen.begin() != ERROR_NONE) {
     /* There was a problem detecting the IC ... check your connections */
-    Serial.print("Ooops, no Si5351 detected ... Check your wiring or I2C ADDR!");
-    while(1);
+    Serial.print(
+        "Ooops, no Si5351 detected ... Check your wiring or I2C ADDR!");
+    while (1)
+      ;
   }
 
   Serial.println("OK!");
@@ -57,6 +58,4 @@ void setup(void)
     should go here)
 */
 /**************************************************************************/
-void loop(void)
-{
-}
+void loop(void) {}


### PR DESCRIPTION
I added a parameter to `Adafruit_SI5351::setupMultisynth` to support the phase offset feature.

I heavily leaned on G0UPL's write up of how to generate quadrature output for the details of how the phase offset works:
https://www.qrp-labs.com/images/news/dayton2018/fdim2018.pdf
See pages 13-17.

In the same document he clarifies the proper function of the (poorly named) PLL reset command, so I also changed `Adafruit_SI5351::setupMultisynth` and `Adafruit_SI5351::setupPLL` to reflect this.