### PR TITLE
Fixes issue 18: enables operation above 150 MHz

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -410,6 +410,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   ASSERT(denom > 0, ERROR_INVALIDPARAMETER);        /* Avoid divide by zero */
   ASSERT(num <= 0xFFFFF, ERROR_INVALIDPARAMETER);   /* 20-bit limit */
   ASSERT(denom <= 0xFFFFF, ERROR_INVALIDPARAMETER); /* 20-bit limit */
+  ASSERT(((num == 0) || (div == 8)), ERROR_INVALIDPARAMETER); /* Fractional division in an output multisynth is only allowed if the integer part of the divisor is 8 */
 
   /* Make sure the requested PLL has been initialised */
   if (pllSource == SI5351_PLL_A) {
@@ -440,7 +441,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
     /* Integer mode */
     P1 = 128 * div - 512;
     P2 = 0;
-    P3 = denom;
+    P3 = 1; /* the denominator doesn't matter for integer division, and it's required to be set to 1 for according to section 4.1.3 of app note AN619 for frequencies above 150 MHz, so just set it to 1 for all integral division. */
   } else if (denom == 1) {
     /* Fractional mode, simplified calculations */
     P1 = 128 * div + 128 * num - 512;
@@ -474,7 +475,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   sendBuffer[0] = baseaddr;
   sendBuffer[1] = (P3 & 0xFF00) >> 8;
   sendBuffer[2] = P3 & 0xFF;
-  sendBuffer[3] = ((P1 & 0x30000) >> 16) | lastRdivValue[output];
+  sendBuffer[3] = ((P1 & 0x30000) >> 16) | lastRdivValue[output] | (div==4?0B1100:0B0000); /* this sets the DIVBY4 bits if needed */
   sendBuffer[4] = (P1 & 0xFF00) >> 8;
   sendBuffer[5] = P1 & 0xFF;
   sendBuffer[6] = ((P3 & 0xF0000) >> 12) | ((P2 & 0xF0000) >> 16);


### PR DESCRIPTION
Three changes were made to the function setupMultisynth in the Adafruit_Si5351.cpp file. The main change is to write to the DIVBY4 register if an integral divide by 4 operation is performed by an output multisynth. In app note AN619, section 4.1.3, it states that this is required for operation above 150 MHz. In the same section, the app note states that P3 should be set equal to 1. It is not clear from the app note if this is a required setting, or merely an acceptable setting. In any case, the denominator shouldn't mtter if the numerator is zero. The simplest way to set this in the code is to always set P3 = 1 when performing integral division, so this change was made. Lastly, because the code sets the DIVBY4 bits only based upon the integral *part* of the divisor, we should do a check to make sure that programmers are not attempting to perform fractional division with any integral part other than 8. An ASSERT statement has been added to detect this bug.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
