### PR TITLE
Improved compatibility with arduino-pico.

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -51,6 +51,8 @@
 #include <util/delay.h>
 #elif defined(ESP8266) || defined(ESP32)
 #include "pgmspace.h"
+#elif defined(ARDUINO_ARCH_RP2040) && !defined(__MBED__)
+#include "pgmspace.h"
 #else
 #define pgm_read_byte(addr) \
   (*(const unsigned char*)(addr)) //!< Reads byte from address

--- a/examples/si5351/si5351.ino
+++ b/examples/si5351/si5351.ino
@@ -10,6 +10,7 @@ Adafruit_SI5351 clockgen = Adafruit_SI5351();
 void setup(void)
 {
   Serial.begin(9600);
+  while(!Serial);
   Serial.println("Si5351 Clockgen Test"); Serial.println("");
 
   /* Initialise the sensor */


### PR DESCRIPTION
This pull request fixed two issues when using this library on a Raspberry Pi Pico running [arduino-pico](https://github.com/earlephilhower/arduino-pico).

1. Adafruit_SI5351.cpp is modified to include pgmspace.h if the target is an RP2040 or RP2350 running arduino-pico. Previously, the `pgm_read_byte()` macro will lead to compile error due to conflict with the `pgm_read_byte()` function in the arduino-pico package.
2. The si5351.ino example is modified to spin the processor while the serial port establishes connection with the host. Previously, I found that printing to serial will be lost during the setup. By adding `while(!Serial);`, the issue is resolved.