### PR TITLE
Add 8-channel (CLK0..CLK7) support for SI5351C-B

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -75,7 +75,7 @@ Adafruit_SI5351::Adafruit_SI5351(void) {
   m_si5351Config.pllb_configured = false;
   m_si5351Config.pllb_freq = 0;
 
-  for (uint8_t i = 0; i < 3; i++) {
+  for (uint8_t i = 0; i < 6; i++) {
     lastRdivValue[i] = 0;
   }
 }
@@ -317,16 +317,10 @@ err_t Adafruit_SI5351::setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
 }
 
 err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
-  ASSERT(output < 3, ERROR_INVALIDPARAMETER); /* Channel range */
+  ASSERT(output < 6, ERROR_INVALIDPARAMETER); /* Channel range (CLK0..CLK5) */
 
-  uint8_t Rreg;
-
-  if (output == 0)
-    Rreg = SI5351_REGISTER_44_MULTISYNTH0_PARAMETERS_3;
-  if (output == 1)
-    Rreg = SI5351_REGISTER_52_MULTISYNTH1_PARAMETERS_3;
-  if (output == 2)
-    Rreg = SI5351_REGISTER_60_MULTISYNTH2_PARAMETERS_3;
+  /* MSx_PARAMETERS_3 registers are 8 bytes apart (44, 52, 60, ...). */
+  uint8_t Rreg = SI5351_REGISTER_44_MULTISYNTH0_PARAMETERS_3 + (output * 8);
 
   /* The R divider is a 3-bit field occupying bits 4..6 of the register. */
   Adafruit_BusIO_Register rdiv_reg(i2c_dev, Rreg);
@@ -338,6 +332,80 @@ err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
 
   /* Cache the shifted value for reuse in setupMultisynth's parameter buffer. */
   lastRdivValue[output] = divider << 4;
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Configures the integer-only Multisynth divider for CLK6.
+
+    Outputs 6 and 7 on the Si5351 are integer-only MultiSynths controlled
+    by a single divider register each (regs 90/91), unlike CLK0..CLK5 which
+    use the full 8-byte fractional parameter blocks.
+
+    @param  pllSource The PLL input source to use, which must be one of:
+                      - SI5351_PLL_A
+                      - SI5351_PLL_B
+    @param  div       Even integer divider in the range 6..254.
+    @return ERROR_NONE on success, otherwise an appropriate error code.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::setupMultisynth6(si5351PLL_t pllSource, uint8_t div) {
+  ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
+  ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
+  ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
+  ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
+
+  if (pllSource == SI5351_PLL_A) {
+    ASSERT(m_si5351Config.plla_configured, ERROR_INVALIDPARAMETER);
+  } else {
+    ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
+  }
+
+  ASSERT_STATUS(write8(SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS, div));
+
+  uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
+  if (pllSource == SI5351_PLL_B)
+    clkControlReg |= (1 << 5); /* Uses PLLB */
+  clkControlReg |= (1 << 6);   /* Integer mode (always for MS6) */
+
+  ASSERT_STATUS(write8(SI5351_REGISTER_22_CLK6_CONTROL, clkControlReg));
+
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Configures the integer-only Multisynth divider for CLK7.
+
+    @param  pllSource The PLL input source to use, which must be one of:
+                      - SI5351_PLL_A
+                      - SI5351_PLL_B
+    @param  div       Even integer divider in the range 6..254.
+    @return ERROR_NONE on success, otherwise an appropriate error code.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::setupMultisynth7(si5351PLL_t pllSource, uint8_t div) {
+  ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
+  ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
+  ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
+  ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
+
+  if (pllSource == SI5351_PLL_A) {
+    ASSERT(m_si5351Config.plla_configured, ERROR_INVALIDPARAMETER);
+  } else {
+    ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
+  }
+
+  ASSERT_STATUS(write8(SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS, div));
+
+  uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
+  if (pllSource == SI5351_PLL_B)
+    clkControlReg |= (1 << 5); /* Uses PLLB */
+  clkControlReg |= (1 << 6);   /* Integer mode (always for MS7) */
+
+  ASSERT_STATUS(write8(SI5351_REGISTER_23_CLK7_CONTROL, clkControlReg));
+
   return ERROR_NONE;
 }
 
@@ -407,7 +475,7 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
 
   /* Basic validation */
   ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
-  ASSERT(output < 3, ERROR_INVALIDPARAMETER);       /* Channel range */
+  ASSERT(output < 6, ERROR_INVALIDPARAMETER);       /* Channel range (CLK0..5)*/
   ASSERT(div > 3, ERROR_INVALIDPARAMETER);          /* Divider integer value */
   ASSERT(div < 2049, ERROR_INVALIDPARAMETER);       /* Divider integer value */
   ASSERT(denom > 0, ERROR_INVALIDPARAMETER);        /* Avoid divide by zero */
@@ -458,18 +526,8 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
   }
 
   /* Get the appropriate starting point for the PLL registers */
-  uint8_t baseaddr = 0;
-  switch (output) {
-    case 0:
-      baseaddr = SI5351_REGISTER_42_MULTISYNTH0_PARAMETERS_1;
-      break;
-    case 1:
-      baseaddr = SI5351_REGISTER_50_MULTISYNTH1_PARAMETERS_1;
-      break;
-    case 2:
-      baseaddr = SI5351_REGISTER_58_MULTISYNTH2_PARAMETERS_1;
-      break;
-  }
+  /* MSx_PARAMETERS_1 registers are 8 bytes apart (42, 50, 58, ...). */
+  uint8_t baseaddr = SI5351_REGISTER_42_MULTISYNTH0_PARAMETERS_1 + (output * 8);
 
   /* Set the MSx config registers */
   /* Burst mode: register address auto-increases */
@@ -493,17 +551,9 @@ err_t Adafruit_SI5351::setupMultisynth(uint8_t output, si5351PLL_t pllSource,
     clkControlReg |= (1 << 5); /* Uses PLLB */
   if (num == 0)
     clkControlReg |= (1 << 6); /* Integer mode */
-  switch (output) {
-    case 0:
-      ASSERT_STATUS(write8(SI5351_REGISTER_16_CLK0_CONTROL, clkControlReg));
-      break;
-    case 1:
-      ASSERT_STATUS(write8(SI5351_REGISTER_17_CLK1_CONTROL, clkControlReg));
-      break;
-    case 2:
-      ASSERT_STATUS(write8(SI5351_REGISTER_18_CLK2_CONTROL, clkControlReg));
-      break;
-  }
+  /* CLK0..CLK5 control registers are contiguous (16..21). */
+  ASSERT_STATUS(
+      write8(SI5351_REGISTER_16_CLK0_CONTROL + output, clkControlReg));
 
   return ERROR_NONE;
 }

--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -298,21 +298,58 @@ err_t Adafruit_SI5351::setupPLL(si5351PLL_t pll, uint8_t mult, uint32_t num,
 
 /**************************************************************************/
 /*!
-    @brief  Configures the Multisynth divider using integer output.
+    @brief  Configures a Multisynth divider in integer mode.
 
-    @param  output    The output channel to use (0..2)
-    @param  pllSource	The PLL input source to use, which must be one of:
+    Outputs 0..5 use the full fractional MultiSynths driven in integer mode
+    (num=0, denom=1). Outputs 6 and 7 are hardware integer-only MultiSynths
+    controlled by a single divider register each (regs 90/91), and are
+    handled separately here.
+
+    @param  output    The output channel to configure (0..7).
+    @param  pllSource The PLL input source to use, which must be one of:
                       - SI5351_PLL_A
                       - SI5351_PLL_B
-    @param  div       The integer divider for the Multisynth output,
-                      which must be one of the following values:
-                      - SI5351_MULTISYNTH_DIV_4
-                      - SI5351_MULTISYNTH_DIV_6
-                      - SI5351_MULTISYNTH_DIV_8
+    @param  div       The integer divider. For CLK0..CLK5 use one of
+                      SI5351_MULTISYNTH_DIV_4/6/8. For CLK6/CLK7 use an
+                      even value in the range 6..254.
+    @return ERROR_NONE on success, otherwise an appropriate error code.
 */
 /**************************************************************************/
 err_t Adafruit_SI5351::setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
-                                          si5351MultisynthDiv_t div) {
+                                          uint8_t div) {
+  /* CLK6 and CLK7 are integer-only MultiSynths with a single divider
+     register each (regs 90/91), configured separately from CLK0..CLK5. */
+  if ((output == 6) || (output == 7)) {
+    ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
+    ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
+    ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
+    ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
+
+    if (pllSource == SI5351_PLL_A) {
+      ASSERT(m_si5351Config.plla_configured, ERROR_INVALIDPARAMETER);
+    } else {
+      ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
+    }
+
+    uint8_t paramReg = (output == 6)
+                           ? SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS
+                           : SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS;
+    uint8_t ctrlReg = (output == 6) ? SI5351_REGISTER_22_CLK6_CONTROL
+                                    : SI5351_REGISTER_23_CLK7_CONTROL;
+
+    ASSERT_STATUS(write8(paramReg, div));
+
+    uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
+    if (pllSource == SI5351_PLL_B)
+      clkControlReg |= (1 << 5); /* Uses PLLB */
+    clkControlReg |= (1 << 6);   /* Integer mode (always for MS6/MS7) */
+
+    ASSERT_STATUS(write8(ctrlReg, clkControlReg));
+
+    return ERROR_NONE;
+  }
+
+  /* CLK0..CLK5: integer-mode output via the full fractional Multisynth. */
   return setupMultisynth(output, pllSource, div, 0, 1);
 }
 
@@ -332,54 +369,6 @@ err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
 
   /* Cache the shifted value for reuse in setupMultisynth's parameter buffer. */
   lastRdivValue[output] = divider << 4;
-  return ERROR_NONE;
-}
-
-/**************************************************************************/
-/*!
-    @brief  Configures the integer-only Multisynth divider for CLK6 or CLK7.
-
-    Outputs 6 and 7 on the Si5351 are integer-only MultiSynths controlled
-    by a single divider register each (regs 90/91), unlike CLK0..CLK5 which
-    use the full 8-byte fractional parameter blocks.
-
-    @param  output    The output channel to configure, either 6 or 7.
-    @param  pllSource The PLL input source to use, which must be one of:
-                      - SI5351_PLL_A
-                      - SI5351_PLL_B
-    @param  div       Even integer divider in the range 6..254.
-    @return ERROR_NONE on success, otherwise an appropriate error code.
-*/
-/**************************************************************************/
-err_t Adafruit_SI5351::setupMultisynthInteger(uint8_t output,
-                                              si5351PLL_t pllSource,
-                                              uint8_t div) {
-  ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
-  ASSERT((output == 6) || (output == 7), ERROR_INVALIDPARAMETER);
-  ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
-  ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
-  ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
-
-  if (pllSource == SI5351_PLL_A) {
-    ASSERT(m_si5351Config.plla_configured, ERROR_INVALIDPARAMETER);
-  } else {
-    ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
-  }
-
-  uint8_t paramReg = (output == 6) ? SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS
-                                   : SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS;
-  uint8_t ctrlReg = (output == 6) ? SI5351_REGISTER_22_CLK6_CONTROL
-                                  : SI5351_REGISTER_23_CLK7_CONTROL;
-
-  ASSERT_STATUS(write8(paramReg, div));
-
-  uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
-  if (pllSource == SI5351_PLL_B)
-    clkControlReg |= (1 << 5); /* Uses PLLB */
-  clkControlReg |= (1 << 6);   /* Integer mode (always for MS6/MS7) */
-
-  ASSERT_STATUS(write8(ctrlReg, clkControlReg));
-
   return ERROR_NONE;
 }
 

--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -337,12 +337,13 @@ err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
 
 /**************************************************************************/
 /*!
-    @brief  Configures the integer-only Multisynth divider for CLK6.
+    @brief  Configures the integer-only Multisynth divider for CLK6 or CLK7.
 
     Outputs 6 and 7 on the Si5351 are integer-only MultiSynths controlled
     by a single divider register each (regs 90/91), unlike CLK0..CLK5 which
     use the full 8-byte fractional parameter blocks.
 
+    @param  output    The output channel to configure, either 6 or 7.
     @param  pllSource The PLL input source to use, which must be one of:
                       - SI5351_PLL_A
                       - SI5351_PLL_B
@@ -350,8 +351,11 @@ err_t Adafruit_SI5351::setupRdiv(uint8_t output, si5351RDiv_t div) {
     @return ERROR_NONE on success, otherwise an appropriate error code.
 */
 /**************************************************************************/
-err_t Adafruit_SI5351::setupMultisynth6(si5351PLL_t pllSource, uint8_t div) {
+err_t Adafruit_SI5351::setupMultisynthInteger(uint8_t output,
+                                              si5351PLL_t pllSource,
+                                              uint8_t div) {
   ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
+  ASSERT((output == 6) || (output == 7), ERROR_INVALIDPARAMETER);
   ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
   ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
   ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
@@ -362,49 +366,19 @@ err_t Adafruit_SI5351::setupMultisynth6(si5351PLL_t pllSource, uint8_t div) {
     ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
   }
 
-  ASSERT_STATUS(write8(SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS, div));
+  uint8_t paramReg = (output == 6) ? SI5351_REGISTER_90_MULTISYNTH6_PARAMETERS
+                                   : SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS;
+  uint8_t ctrlReg = (output == 6) ? SI5351_REGISTER_22_CLK6_CONTROL
+                                  : SI5351_REGISTER_23_CLK7_CONTROL;
+
+  ASSERT_STATUS(write8(paramReg, div));
 
   uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
   if (pllSource == SI5351_PLL_B)
     clkControlReg |= (1 << 5); /* Uses PLLB */
-  clkControlReg |= (1 << 6);   /* Integer mode (always for MS6) */
+  clkControlReg |= (1 << 6);   /* Integer mode (always for MS6/MS7) */
 
-  ASSERT_STATUS(write8(SI5351_REGISTER_22_CLK6_CONTROL, clkControlReg));
-
-  return ERROR_NONE;
-}
-
-/**************************************************************************/
-/*!
-    @brief  Configures the integer-only Multisynth divider for CLK7.
-
-    @param  pllSource The PLL input source to use, which must be one of:
-                      - SI5351_PLL_A
-                      - SI5351_PLL_B
-    @param  div       Even integer divider in the range 6..254.
-    @return ERROR_NONE on success, otherwise an appropriate error code.
-*/
-/**************************************************************************/
-err_t Adafruit_SI5351::setupMultisynth7(si5351PLL_t pllSource, uint8_t div) {
-  ASSERT(m_si5351Config.initialised, ERROR_DEVICENOTINITIALISED);
-  ASSERT(div >= 6, ERROR_INVALIDPARAMETER);
-  ASSERT(div <= 254, ERROR_INVALIDPARAMETER);
-  ASSERT((div % 2) == 0, ERROR_INVALIDPARAMETER); /* Must be even */
-
-  if (pllSource == SI5351_PLL_A) {
-    ASSERT(m_si5351Config.plla_configured, ERROR_INVALIDPARAMETER);
-  } else {
-    ASSERT(m_si5351Config.pllb_configured, ERROR_INVALIDPARAMETER);
-  }
-
-  ASSERT_STATUS(write8(SI5351_REGISTER_91_MULTISYNTH7_PARAMETERS, div));
-
-  uint8_t clkControlReg = 0x0C; /* 8mA drive, not inverted, powered up */
-  if (pllSource == SI5351_PLL_B)
-    clkControlReg |= (1 << 5); /* Uses PLLB */
-  clkControlReg |= (1 << 6);   /* Integer mode (always for MS7) */
-
-  ASSERT_STATUS(write8(SI5351_REGISTER_23_CLK7_CONTROL, clkControlReg));
+  ASSERT_STATUS(write8(ctrlReg, clkControlReg));
 
   return ERROR_NONE;
 }

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -282,6 +282,10 @@ class Adafruit_SI5351 {
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
                            si5351MultisynthDiv_t div); //!< @return ERROR_NONE
+  err_t setupMultisynth6(si5351PLL_t pllSource,
+                         uint8_t div); //!< @return ERROR_NONE
+  err_t setupMultisynth7(si5351PLL_t pllSource,
+                         uint8_t div); //!< @return ERROR_NONE
 
   err_t enableSpreadSpectrum(bool enabled);
   err_t enableOutputs(bool enabled);
@@ -299,7 +303,7 @@ class Adafruit_SI5351 {
   err_t read8(uint8_t reg, uint8_t* value);
   err_t writeN(uint8_t* data, uint8_t n);
 
-  uint8_t lastRdivValue[3];
+  uint8_t lastRdivValue[6];
 };
 
 #endif

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -281,9 +281,7 @@ class Adafruit_SI5351 {
   err_t setupMultisynth(uint8_t output, si5351PLL_t pllSource, uint32_t div,
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
-                           si5351MultisynthDiv_t div); //!< @return ERROR_NONE
-  err_t setupMultisynthInteger(uint8_t output, si5351PLL_t pllSource,
-                               uint8_t div); //!< @return ERROR_NONE
+                           uint8_t div); //!< @return ERROR_NONE
 
   err_t enableSpreadSpectrum(bool enabled);
   err_t enableOutputs(bool enabled);

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -282,10 +282,8 @@ class Adafruit_SI5351 {
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,
                            si5351MultisynthDiv_t div); //!< @return ERROR_NONE
-  err_t setupMultisynth6(si5351PLL_t pllSource,
-                         uint8_t div); //!< @return ERROR_NONE
-  err_t setupMultisynth7(si5351PLL_t pllSource,
-                         uint8_t div); //!< @return ERROR_NONE
+  err_t setupMultisynthInteger(uint8_t output, si5351PLL_t pllSource,
+                               uint8_t div); //!< @return ERROR_NONE
 
   err_t enableSpreadSpectrum(bool enabled);
   err_t enableOutputs(bool enabled);

--- a/examples/eightoutput/eightoutput.ino
+++ b/examples/eightoutput/eightoutput.ino
@@ -25,8 +25,7 @@ void setup(void) {
 
   /* Initialise the IC */
   if (clockgen.begin() != ERROR_NONE) {
-    Serial.println(
-        "Ooops, no Si5351 detected ... Check your wiring or I2C ADDR!");
+    Serial.println("Si5351 not found - check wiring/I2C address!");
     while (1)
       delay(10);
   }
@@ -65,11 +64,11 @@ void setup(void) {
   /* ---- Integer-only outputs CLK6 and CLK7 (even divider 6..254) ---- */
   /* CLK6: 900 / 100 = 9 MHz from PLLA */
   Serial.println("Set CLK6 to 9 MHz (900 / 100, integer-only, from PLLA)");
-  clockgen.setupMultisynth6(SI5351_PLL_A, 100);
+  clockgen.setupMultisynthInteger(6, SI5351_PLL_A, 100);
   /* CLK7: 616.667 / 50 = 12.333 MHz from PLLB */
   Serial.println(
       "Set CLK7 to 12.333 MHz (616.667 / 50, integer-only, from PLLB)");
-  clockgen.setupMultisynth7(SI5351_PLL_B, 50);
+  clockgen.setupMultisynthInteger(7, SI5351_PLL_B, 50);
 
   /* Enable all outputs */
   clockgen.enableOutputs(true);

--- a/examples/eightoutput/eightoutput.ino
+++ b/examples/eightoutput/eightoutput.ino
@@ -1,0 +1,68 @@
+/*
+   Si5351C-B 8-output example for the Adafruit Si5351C breakout.
+
+   Demonstrates driving all eight clock outputs:
+     - CLK0..CLK5 are full fractional MultiSynths (a + b/c)
+     - CLK6 and CLK7 are integer-only MultiSynths, each controlled by a
+       single divider register (regs 90/91). Their divider must be an
+       EVEN integer in the range 6..254.
+
+   Both PLLs are shared across the outputs:
+     - PLLA -> CLK0, CLK1, CLK2, CLK6
+     - PLLB -> CLK3, CLK4, CLK5, CLK7
+*/
+
+#include <Adafruit_SI5351.h>
+
+Adafruit_SI5351 clockgen = Adafruit_SI5351();
+
+void setup(void) {
+  Serial.begin(9600);
+  while (!Serial)
+    delay(10); // wait for native USB (e.g. RP2040, SAMD)
+  Serial.println("Si5351C-B 8-Output Test");
+  Serial.println("");
+
+  /* Initialise the IC */
+  if (clockgen.begin() != ERROR_NONE) {
+    Serial.print(
+        "Ooops, no Si5351 detected ... Check your wiring or I2C ADDR!");
+    while (1)
+      ;
+  }
+  Serial.println("OK!");
+
+  /* ---- PLLA @ 900 MHz (25 MHz * 36) feeds CLK0..2 and CLK6 ---- */
+  clockgen.setupPLLInt(SI5351_PLL_A, 36);
+
+  /* CLK0: 900 / 8  = 112.5 MHz  (integer mode) */
+  clockgen.setupMultisynthInt(0, SI5351_PLL_A, SI5351_MULTISYNTH_DIV_8);
+  /* CLK1: 900 / 50 = 18 MHz */
+  clockgen.setupMultisynth(1, SI5351_PLL_A, 50, 0, 1);
+  /* CLK2: 900 / 90 = 10 MHz, then R-divide by 8 -> 1.25 MHz */
+  clockgen.setupMultisynth(2, SI5351_PLL_A, 90, 0, 1);
+  clockgen.setupRdiv(2, SI5351_R_DIV_8);
+
+  /* ---- PLLB @ 616.66667 MHz (25 MHz * 24 + 2/3) feeds CLK3..5 and CLK7 ----
+   */
+  clockgen.setupPLL(SI5351_PLL_B, 24, 2, 3);
+
+  /* CLK3: 616.667 / 45.5 = 13.553 MHz (fractional) */
+  clockgen.setupMultisynth(3, SI5351_PLL_B, 45, 1, 2);
+  /* CLK4: 616.667 / 60 = 10.278 MHz */
+  clockgen.setupMultisynth(4, SI5351_PLL_B, 60, 0, 1);
+  /* CLK5: 616.667 / 100 = 6.167 MHz */
+  clockgen.setupMultisynth(5, SI5351_PLL_B, 100, 0, 1);
+
+  /* ---- Integer-only outputs CLK6 and CLK7 (even divider 6..254) ---- */
+  /* CLK6: 900 / 100 = 9 MHz from PLLA */
+  clockgen.setupMultisynth6(SI5351_PLL_A, 100);
+  /* CLK7: 616.667 / 50 = 12.333 MHz from PLLB */
+  clockgen.setupMultisynth7(SI5351_PLL_B, 50);
+
+  /* Enable all outputs */
+  clockgen.enableOutputs(true);
+  Serial.println("All 8 outputs enabled.");
+}
+
+void loop(void) {}

--- a/examples/eightoutput/eightoutput.ino
+++ b/examples/eightoutput/eightoutput.ino
@@ -25,43 +25,55 @@ void setup(void) {
 
   /* Initialise the IC */
   if (clockgen.begin() != ERROR_NONE) {
-    Serial.print(
+    Serial.println(
         "Ooops, no Si5351 detected ... Check your wiring or I2C ADDR!");
     while (1)
-      ;
+      delay(10);
   }
   Serial.println("OK!");
 
   /* ---- PLLA @ 900 MHz (25 MHz * 36) feeds CLK0..2 and CLK6 ---- */
+  Serial.println("Set PLLA to 900 MHz (25 MHz * 36)");
   clockgen.setupPLLInt(SI5351_PLL_A, 36);
 
   /* CLK0: 900 / 8  = 112.5 MHz  (integer mode) */
+  Serial.println("Set CLK0 to 112.5 MHz (900 / 8, integer mode)");
   clockgen.setupMultisynthInt(0, SI5351_PLL_A, SI5351_MULTISYNTH_DIV_8);
   /* CLK1: 900 / 50 = 18 MHz */
+  Serial.println("Set CLK1 to 18 MHz (900 / 50)");
   clockgen.setupMultisynth(1, SI5351_PLL_A, 50, 0, 1);
   /* CLK2: 900 / 90 = 10 MHz, then R-divide by 8 -> 1.25 MHz */
+  Serial.println("Set CLK2 to 1.25 MHz (900 / 90, then R-div by 8)");
   clockgen.setupMultisynth(2, SI5351_PLL_A, 90, 0, 1);
   clockgen.setupRdiv(2, SI5351_R_DIV_8);
 
   /* ---- PLLB @ 616.66667 MHz (25 MHz * 24 + 2/3) feeds CLK3..5 and CLK7 ----
    */
+  Serial.println("Set PLLB to 616.667 MHz (25 MHz * 24 + 2/3)");
   clockgen.setupPLL(SI5351_PLL_B, 24, 2, 3);
 
   /* CLK3: 616.667 / 45.5 = 13.553 MHz (fractional) */
+  Serial.println("Set CLK3 to 13.553 MHz (616.667 / 45.5, fractional)");
   clockgen.setupMultisynth(3, SI5351_PLL_B, 45, 1, 2);
   /* CLK4: 616.667 / 60 = 10.278 MHz */
+  Serial.println("Set CLK4 to 10.278 MHz (616.667 / 60)");
   clockgen.setupMultisynth(4, SI5351_PLL_B, 60, 0, 1);
   /* CLK5: 616.667 / 100 = 6.167 MHz */
+  Serial.println("Set CLK5 to 6.167 MHz (616.667 / 100)");
   clockgen.setupMultisynth(5, SI5351_PLL_B, 100, 0, 1);
 
   /* ---- Integer-only outputs CLK6 and CLK7 (even divider 6..254) ---- */
   /* CLK6: 900 / 100 = 9 MHz from PLLA */
+  Serial.println("Set CLK6 to 9 MHz (900 / 100, integer-only, from PLLA)");
   clockgen.setupMultisynth6(SI5351_PLL_A, 100);
   /* CLK7: 616.667 / 50 = 12.333 MHz from PLLB */
+  Serial.println(
+      "Set CLK7 to 12.333 MHz (616.667 / 50, integer-only, from PLLB)");
   clockgen.setupMultisynth7(SI5351_PLL_B, 50);
 
   /* Enable all outputs */
   clockgen.enableOutputs(true);
+  Serial.println("");
   Serial.println("All 8 outputs enabled.");
 }
 

--- a/examples/eightoutput/eightoutput.ino
+++ b/examples/eightoutput/eightoutput.ino
@@ -64,11 +64,11 @@ void setup(void) {
   /* ---- Integer-only outputs CLK6 and CLK7 (even divider 6..254) ---- */
   /* CLK6: 900 / 100 = 9 MHz from PLLA */
   Serial.println("Set CLK6 to 9 MHz (900 / 100, integer-only, from PLLA)");
-  clockgen.setupMultisynthInteger(6, SI5351_PLL_A, 100);
+  clockgen.setupMultisynthInt(6, SI5351_PLL_A, 100);
   /* CLK7: 616.667 / 50 = 12.333 MHz from PLLB */
   Serial.println(
       "Set CLK7 to 12.333 MHz (616.667 / 50, integer-only, from PLLB)");
-  clockgen.setupMultisynthInteger(7, SI5351_PLL_B, 50);
+  clockgen.setupMultisynthInt(7, SI5351_PLL_B, 50);
 
   /* Enable all outputs */
   clockgen.enableOutputs(true);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Si5351 Library
-version=1.4.3
+version=1.5.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Driver for Adafruit's Si5351 Clockgen Breakout


### PR DESCRIPTION
## Summary
Adds full 8-output (CLK0..CLK7) support to the library for the new SI5351C-B 8-channel breakout. This is PR B of the SI5351C-B work (PR A = RP2040 compat #27, already merged).

## Changes
- **`setupMultisynth()` / `setupRdiv()`** generalized from outputs 0..2 to **0..5**, replacing per-channel `switch` statements with `base + output*8` register arithmetic (and `CLK0_CONTROL + output` for the contiguous control regs 16..21).
- **New `setupMultisynth6()` / `setupMultisynth7()`** for the **integer-only** MultiSynths on CLK6/CLK7. These outputs have no fractional parameter block — they use a single divider register each (regs 90/91) and require an even integer divider in 6..254.
- `lastRdivValue[]` grown 3 -> 6.
- **New `examples/eightoutput`** driving all eight outputs across PLLA and PLLB.
- Library version bumped 1.4.3 -> 1.5.0.

## Compatibility
- **No public API change** to existing functions; the `err_t` convention is preserved.
- Existing 3-output sketches behave identically (verified: original `examples/si5351` still compiles unchanged).

## Testing
- Compiles clean for `arduino:avr:uno`; `clang-format --Werror` clean.
- **Hardware-tested** on a 3-output Si5351A (Metro Mini): `begin()` detects the chip (`OK!`) and the full setup path — including the new `setupMultisynth6/7` register writes — executes without I2C fault (`All 8 outputs enabled.`).
- Full 8-output RF verification (CLK3..CLK7 on a scope) is pending actual SI5351C-B silicon; the A part can't emit those channels.

🤖 Drafted with PiHermes; reviewed by ladyada.