### PR TITLE
Add device status / interrupt register API (reg 0/1/2)

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -667,6 +667,60 @@ err_t Adafruit_SI5351::enableOutputs(bool enabled) {
 
 /**************************************************************************/
 /*!
+    @brief  Reads the current device status register.
+
+    @param  device_status Pointer to where register 0 value will be stored.
+    @return ERROR_NONE on success, or an I2C/parameter error.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::readDeviceStatus(uint8_t* device_status) {
+  ASSERT(device_status != NULL, ERROR_INVALIDPARAMETER);
+  ASSERT_STATUS(read8(SI5351_REGISTER_0_DEVICE_STATUS, device_status));
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads the sticky interrupt status register.
+
+    @param  sticky Pointer to where register 1 value will be stored.
+    @return ERROR_NONE on success, or an I2C/parameter error.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::readStickyStatus(uint8_t* sticky) {
+  ASSERT(sticky != NULL, ERROR_INVALIDPARAMETER);
+  ASSERT_STATUS(read8(SI5351_REGISTER_1_INTERRUPT_STATUS_STICKY, sticky));
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Clears all sticky interrupt flags.
+
+    @return ERROR_NONE on success, or ERROR_I2C_TRANSACTION on failure.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::clearStickyStatus(void) {
+  ASSERT_STATUS(write8(SI5351_REGISTER_1_INTERRUPT_STATUS_STICKY, 0x00));
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Sets the interrupt status mask register.
+
+    @param  mask Register 2 bitmask where 1 masks (disables) an interrupt
+   source.
+    @return ERROR_NONE on success, or ERROR_I2C_TRANSACTION on failure.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::setInterruptMask(uint8_t mask) {
+  ASSERT_STATUS(write8(SI5351_REGISTER_2_INTERRUPT_STATUS_MASK, mask));
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
     @brief  Enables or disables spread spectrum
     @param  enabled Whether spread spectrum output is enabled
     @return ERROR_NONE

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -219,6 +219,11 @@ enum {
   SI5351_REGISTER_183_CRYSTAL_INTERNAL_LOAD_CAPACITANCE = 183
 };
 
+#define SI5351_STATUS_SYS_INIT (1 << 7)  ///< Device initializing
+#define SI5351_STATUS_LOL_B (1 << 6)     ///< PLL B loss of lock
+#define SI5351_STATUS_LOL_A (1 << 5)     ///< PLL A loss of lock
+#define SI5351_STATUS_LOS_CLKIN (1 << 4) ///< CLKIN loss of signal (Si5351C)
+
 typedef enum {
   SI5351_PLL_A = 0,
   SI5351_PLL_B,
@@ -285,6 +290,12 @@ class Adafruit_SI5351 {
 
   err_t enableSpreadSpectrum(bool enabled);
   err_t enableOutputs(bool enabled);
+  err_t readDeviceStatus(
+      uint8_t* device_status);             //!< Read register 0 status byte
+  err_t readStickyStatus(uint8_t* sticky); //!< Read register 1 sticky byte
+  err_t clearStickyStatus(void);           //!< Clear register 1 sticky flags
+  err_t setInterruptMask(
+      uint8_t mask); //!< Write register 2 interrupt mask byte
   /*!
    * @param output Enables or disables output
    * @param div Set of output divider values (2^n, n=1..7)


### PR DESCRIPTION
Adds an I2C status/interrupt-register API to complement the Si5351C support:

- `readDeviceStatus()` — register 0 (SYS_INIT, LOL_A/B, LOS_CLKIN)
- `readStickyStatus()` / `clearStickyStatus()` — register 1 sticky flags
- `setInterruptMask()` — register 2 interrupt mask
- `SI5351_STATUS_*` bit defines

Purely additive; existing `err_t`/`ASSERT_STATUS` convention preserved.

**Bench-verified on a Si5351C-B breakout:** reg0 reads 0x11 (device ready, both PLLs locked, LOS_CLKIN asserted as expected with no external CLKIN connected), and `clearStickyStatus()` clears latched LOL bits over I2C.