### PR TITLE
Add setupPLLSource() API for reg 15 (PLL input source / CLKIN divider)

### DIFF
--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -189,6 +189,71 @@ err_t Adafruit_SI5351::setupPLLInt(si5351PLL_t pll, uint8_t mult) {
 
 /**************************************************************************/
 /*!
+    @brief  Selects the reference source (XTAL or CLKIN) for the specified PLL,
+            and optionally sets the CLKIN pre-divider.
+
+    @param  pll       The PLL whose reference source is being configured:
+                      - SI5351_PLL_A
+                      - SI5351_PLL_B
+    @param  source    Reference source for this PLL:
+                      - SI5351_PLL_SOURCE_XTAL  (use the on-board crystal)
+                      - SI5351_PLL_SOURCE_CLKIN (use the external CLKIN pin)
+    @param  clkinDiv  CLKIN pre-divider (reg 15, bits [7:6]). The CLKIN input
+                      to the PLLs must be in the 10..40 MHz range; pick a
+                      divider that brings your CLKIN signal into that window.
+                      Only written when @p source == SI5351_PLL_SOURCE_CLKIN,
+                      so that switching one PLL back to XTAL does not clobber
+                      the divider used by the other PLL.
+                      - SI5351_CLKIN_DIV_1 (default)
+                      - SI5351_CLKIN_DIV_2
+                      - SI5351_CLKIN_DIV_4
+                      - SI5351_CLKIN_DIV_8
+
+    @section Register Map (AN619)
+
+    Register 15 -- PLL Input Source
+
+       Bit  | Field
+      ------+-----------------------------------
+       7:6  | CLKIN_DIV[1:0]
+       5:4  | (reserved)
+        3   | PLLB_SRC  (0 = XTAL, 1 = CLKIN)
+        2   | PLLA_SRC  (0 = XTAL, 1 = CLKIN)
+       1:0  | (reserved)
+
+    Both PLLA_SRC and PLLB_SRC are single-bit fields, so we use
+    Adafruit_BusIO_RegisterBits to read-modify-write only the affected
+    bit and leave the other PLL's source (and the reserved bits) intact.
+
+    @return ERROR_NONE on success, or ERROR_I2C_TRANSACTION on a bus failure.
+*/
+/**************************************************************************/
+err_t Adafruit_SI5351::setupPLLSource(si5351PLL_t pll,
+                                     si5351PLLSource_t source,
+                                     si5351ClkinDiv_t clkinDiv) {
+  Adafruit_BusIO_Register src_reg(i2c_dev,
+                                  SI5351_REGISTER_15_PLL_INPUT_SOURCE);
+
+  /* PLLA_SRC = bit 2, PLLB_SRC = bit 3.  Each is a 1-bit field. */
+  uint8_t srcBit = (pll == SI5351_PLL_A) ? 2 : 3;
+  Adafruit_BusIO_RegisterBits pll_src_bit(&src_reg, 1, srcBit);
+  if (!pll_src_bit.write(source & 0x01))
+    return ERROR_I2C_TRANSACTION;
+
+  /* CLKIN_DIV (bits [7:6]) is shared by both PLLs. Only program it when
+     this PLL is actually being switched to CLKIN, so that flipping one PLL
+     back to XTAL doesn't stomp the divider the other PLL is still using. */
+  if (source == SI5351_PLL_SOURCE_CLKIN) {
+    Adafruit_BusIO_RegisterBits clkin_div_bits(&src_reg, 2, 6);
+    if (!clkin_div_bits.write(clkinDiv & 0x03))
+      return ERROR_I2C_TRANSACTION;
+  }
+
+  return ERROR_NONE;
+}
+
+/**************************************************************************/
+/*!
     @brief  Sets the multiplier for the specified PLL
 
     @param  pll   The PLL to configure, which must be one of the following:

--- a/Adafruit_SI5351.cpp
+++ b/Adafruit_SI5351.cpp
@@ -228,11 +228,9 @@ err_t Adafruit_SI5351::setupPLLInt(si5351PLL_t pll, uint8_t mult) {
     @return ERROR_NONE on success, or ERROR_I2C_TRANSACTION on a bus failure.
 */
 /**************************************************************************/
-err_t Adafruit_SI5351::setupPLLSource(si5351PLL_t pll,
-                                     si5351PLLSource_t source,
-                                     si5351ClkinDiv_t clkinDiv) {
-  Adafruit_BusIO_Register src_reg(i2c_dev,
-                                  SI5351_REGISTER_15_PLL_INPUT_SOURCE);
+err_t Adafruit_SI5351::setupPLLSource(si5351PLL_t pll, si5351PLLSource_t source,
+                                      si5351ClkinDiv_t clkinDiv) {
+  Adafruit_BusIO_Register src_reg(i2c_dev, SI5351_REGISTER_15_PLL_INPUT_SOURCE);
 
   /* PLLA_SRC = bit 2, PLLB_SRC = bit 3.  Each is a 1-bit field. */
   uint8_t srcBit = (pll == SI5351_PLL_A) ? 2 : 3;

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -295,9 +295,9 @@ class Adafruit_SI5351 {
   err_t setupPLL(si5351PLL_t pll, uint8_t mult, uint32_t num,
                  uint32_t denom);                   //!< @return ERROR_NONE
   err_t setupPLLInt(si5351PLL_t pll, uint8_t mult); //!< @return ERROR_NONE
-  err_t setupPLLSource(si5351PLL_t pll, si5351PLLSource_t source,
-                       si5351ClkinDiv_t clkinDiv =
-                           SI5351_CLKIN_DIV_1); //!< @return ERROR_NONE
+  err_t setupPLLSource(
+      si5351PLL_t pll, si5351PLLSource_t source,
+      si5351ClkinDiv_t clkinDiv = SI5351_CLKIN_DIV_1); //!< @return ERROR_NONE
   err_t setupMultisynth(uint8_t output, si5351PLL_t pllSource, uint32_t div,
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,

--- a/Adafruit_SI5351.h
+++ b/Adafruit_SI5351.h
@@ -230,6 +230,18 @@ typedef enum {
 } si5351PLL_t;
 
 typedef enum {
+  SI5351_PLL_SOURCE_XTAL = 0,  ///< PLL source = crystal (reg 15 bit = 0)
+  SI5351_PLL_SOURCE_CLKIN = 1, ///< PLL source = CLKIN  (reg 15 bit = 1)
+} si5351PLLSource_t;
+
+typedef enum {
+  SI5351_CLKIN_DIV_1 = 0, ///< CLKIN /1  (reg 15 bits [7:6] = 00)
+  SI5351_CLKIN_DIV_2 = 1, ///< CLKIN /2  (reg 15 bits [7:6] = 01)
+  SI5351_CLKIN_DIV_4 = 2, ///< CLKIN /4  (reg 15 bits [7:6] = 10)
+  SI5351_CLKIN_DIV_8 = 3, ///< CLKIN /8  (reg 15 bits [7:6] = 11)
+} si5351ClkinDiv_t;
+
+typedef enum {
   SI5351_CRYSTAL_LOAD_6PF = (1 << 6),
   SI5351_CRYSTAL_LOAD_8PF = (2 << 6),
   SI5351_CRYSTAL_LOAD_10PF = (3 << 6)
@@ -283,6 +295,9 @@ class Adafruit_SI5351 {
   err_t setupPLL(si5351PLL_t pll, uint8_t mult, uint32_t num,
                  uint32_t denom);                   //!< @return ERROR_NONE
   err_t setupPLLInt(si5351PLL_t pll, uint8_t mult); //!< @return ERROR_NONE
+  err_t setupPLLSource(si5351PLL_t pll, si5351PLLSource_t source,
+                       si5351ClkinDiv_t clkinDiv =
+                           SI5351_CLKIN_DIV_1); //!< @return ERROR_NONE
   err_t setupMultisynth(uint8_t output, si5351PLL_t pllSource, uint32_t div,
                         uint32_t num, uint32_t denom); //!< @return ERROR_NONE
   err_t setupMultisynthInt(uint8_t output, si5351PLL_t pllSource,


### PR DESCRIPTION
Adds `Adafruit_SI5351::setupPLLSource(pll, source, clkinDiv)` so callers can select XTAL vs CLKIN as the input to PLLA/PLLB and configure the CLKIN pre-divider, per AN619 register 15.

## What this adds
- New enums in the header: `si5351PLLSource_t` (XTAL / CLKIN) and `si5351ClkinDiv_t` (/1 /2 /4 /8).
- `setupPLLSource()` does a per-PLL RMW on reg 15 using `Adafruit_BusIO_RegisterBits`, so the other PLL's source bit and the reserved bits are preserved.
- CLKIN_DIV (bits [7:6]) is only written when this call is switching the PLL **to** CLKIN, so flipping one PLL back to XTAL won't stomp the divider the other PLL is still using.
- `clkinDiv` defaults to `SI5351_CLKIN_DIV_1`.
- Returns `ERROR_I2C_TRANSACTION` on bus failure, `ERROR_NONE` otherwise — matches the existing `err_t` style.

## Why
Si5351**C** can be clocked from CLKIN instead of the on-board crystal, but the library had no API to select it. Reg 15 was already enumerated in the header but unused.

## Tested
- Compiles clean against `examples/si5351` (`arduino-cli compile --fqbn arduino:avr:uno`).
- Bench validation (sourcing PLLA from CLKIN, measuring output tracks the CLKIN reference) is queued as `04_clki` on the `hw_tests` branch (PR #32).

Refs AN619 §3, register 15.
